### PR TITLE
Fix graph disappearance if height changed without setting width

### DIFF
--- a/src/components/Chart/purechart.jsx
+++ b/src/components/Chart/purechart.jsx
@@ -152,8 +152,12 @@ export default class PureChart extends Component {
       chart.filter(nextFilter);
     }
 
-    if (width !== nextWidth || height !== nextHeight) {
+    if (width !== nextWidth && height !== nextHeight) {
       chart.changeSize(nextWidth, nextHeight);
+    } else if (width !== nextWidth) {
+      chart.changeWidth(nextWidth)
+    } else if (height !== nextHeight) {
+      chart.changeHeight(nextHeight)
     }
 
     GEvent.updateEvents(chart, chartEvents, props, nextProps);


### PR DESCRIPTION
Example:
```
<Chart height={height} forceFit>
...
</Chart>
```
The first render works fine, but if height is changed, the original code will trigger:
```
chart.changeSize(undefined, nextHeight);
```
which will make the graph disappear