### PR TITLE
Property "active" of Geom was typed as "Active" which broke the typescript compiler

### DIFF
--- a/doc/api/geom.md
+++ b/doc/api/geom.md
@@ -294,7 +294,7 @@ size 支持映射值如下：
 />
 ```
 
-### 11、Active    * Boolean *
+### 11、active    * Boolean *
 图形激活交互开关。
 
 ### 12、animate    * Object *

--- a/doc_en/api/geom.md
+++ b/doc_en/api/geom.md
@@ -314,8 +314,8 @@ Enable/Disable the click event for shape. Only pie chart enable select mode by d
 />
 ```
 
-### 11、Active    * Boolean *
-Enable/Disable the hover event for shape. 
+### 11、active    * Boolean *
+Enable/Disable the hover event for shape.
 
 ### 12、animate    * Object *
 [See more details about animate](../tutorial/animate.md)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -181,7 +181,7 @@ declare namespace bizcharts{
     style?: object | [string, object];
     tooltip?: boolean | string | [string, (x?: any, y?: any) => {name?: string; value: string}];
     select?: boolean | [boolean, any];
-    Active?: boolean; // 图形激活交互开关
+    active?: boolean; // 图形激活交互开关
     animate?: any;
   }
 

--- a/testDemo/component/geom/updateRect.js
+++ b/testDemo/component/geom/updateRect.js
@@ -127,7 +127,7 @@ export default class Basic extends Component {
       cancelable: this.state.boolean, // 选中之后是否允许取消选中，默认允许取消选中
       animate: this.state.boolean // 选中是否执行动画，默认执行动画
       }]}
-      Active={this.state.boolean}
+      active={this.state.boolean}
       animate={{
         animation: 'fadeIn', // 动画名称
         easing: 'easeInQuart', // 动画缓动效果

--- a/testDemo/component/viewUpdate/geomUpdate.js
+++ b/testDemo/component/viewUpdate/geomUpdate.js
@@ -114,7 +114,7 @@ export default class Basic extends Component {
           cancelable: true | false, // 选中之后是否允许取消选中，默认允许取消选中
           animate: true | false // 选中是否执行动画，默认执行动画
           }]}
-          Active={false}
+          active={false}
           animate={{
             animation: 'fadeIn', // 动画名称
             easing: 'easeInQuart', // 动画缓动效果

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -181,7 +181,7 @@ declare namespace bizcharts{
     style?: object | [string, object];
     tooltip?: boolean | string | [string, (x?: any, y?: any) => {name?: string; value: string}];
     select?: boolean | [boolean, any];
-    Active?: boolean; // 图形激活交互开关
+    active?: boolean; // 图形激活交互开关
     animate?: any;
   }
 


### PR DESCRIPTION
In some places in the code `Geom`'s `active` property was written as `Active` and TypeScript would then complain.