### PR TITLE
padding should allow string type, <Chart padding="auto" />

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -84,6 +84,7 @@ declare namespace bizcharts{
     width?: number;
     height: number;
     padding?:
+      | string
       | {
           top: number;
           right: number;


### PR DESCRIPTION
http://bizcharts.net/products/bizCharts/api/chart
```
<Chart padding="auto" />
<Chart padding={[ 20, 30, 20, 30]} />
<Chart padding={20} />
<Chart padding={{ top: 20, right: 30, bottom: 20, left: 30 }} />
<Chart padding={[20, 'auto', 30, 'auto']} />
<Chart padding={['20%', '30%']} />
```