### PR TITLE
add missing `title` prop for tooltip

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -241,6 +241,7 @@ declare namespace bizcharts{
 
   export interface TooltipProps extends React.Props<any> {
     showTitle?: boolean;
+    title?: string
     crosshairs?: {
       type?: CrosshairsType;
       style?: G2.Styles.background | G2.Styles.line;


### PR DESCRIPTION
按[文档](https://bizcharts.net/products/bizCharts/api/tooltip#title)中的描述，`Tooltip` 组件接受 title 属性，但是类型定义中并没有。