### PR TITLE
fix: geom tooltip prop typing

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -181,7 +181,7 @@ declare namespace bizcharts{
     size?: number | string | [string, [number, number]] | [string, (d?: any) => number];
     opacity?: string | number | [string, (d?: any) => number];
     style?: object | [string, object];
-    tooltip?: boolean | string | [string, (x?: any, y?: any) => {name?: string; value: string}];
+    tooltip?: boolean | string | [string, (...args: any[]) => {name?: string; value: string}];
     select?: boolean | [boolean, any];
     active?: boolean; // 图形激活交互开关
     animate?: any;


### PR DESCRIPTION
根据 [G2 文档](https://www.yuque.com/antv/g2-docs/api-geom#xn4fqp)，tooltip 在 `tooltip(field, callback)` 的用法时，用星号连接的字段名可以超过两个，callback 的参数个数也因此没有限制，目前的类型定义限制参数最多两个，会导致报错。