### PR TITLE
fix:check-if-child-is-null-before-hasViewSource

### DIFF
--- a/src/components/Chart/index.jsx
+++ b/src/components/Chart/index.jsx
@@ -32,7 +32,7 @@ class Chart extends (React.PureComponent || React.Component) {
   hasViewSource = () => {
     let hasViewSource = false;
     React.Children.map(this.props.children, (child) => {
-      if (!hasViewSource && typeof (child.type) === 'function' && child.type.name === 'View' && child.props.data && hasSource(child.props.data)) {
+      if (!hasViewSource && child && typeof (child.type) === 'function' && child.type.name === 'View' && child.props.data && hasSource(child.props.data)) {
         hasViewSource = true;
       }
     });


### PR DESCRIPTION
Check if child is null before check if child is <View>, to avoid usages like following may throw error:

```
<Chart
        height={styleOptions.height}
        data={dv}
        padding="auto"
        scale={cols}
        forceFit
      >
        {(splitFields.length > 0 || yAxisField.length > 1) && <Legend />}
        {xalias && <Axis name={xalias} />}
        <Axis name="percent" title visible={!styleOptions.hideYTitle} />
        <Tooltip />
        <Geom
              type="intervalStack"
              position={`${xalias}*percent`}
              color={["name", '#096dd9-#91d5ff']}
        />
        {styleOptions.isBarChart ? <Coord transpose /> : null}
</Chart>
```