### PR TITLE
remove forceFit always be false

### DIFF
--- a/src/processor/g2Creator.js
+++ b/src/processor/g2Creator.js
@@ -10,7 +10,6 @@ const GEOM_FUNC_PROPS = common.GEOM_FUNC_PROPS;
 export default {
   createChart(config) {
     const chartConfig = config.chart;
-    chartConfig.props.forceFit = false;
     const chart = new G2.Chart(chartConfig.props);
     chartConfig.g2Instance = chart;
     return chart;


### PR DESCRIPTION
according to the #881 #888 #880, in v3.5.4, chart will be re-rendered twice and a weird flash will appear. I found the `forceFit` prop is always be `false` in  the `g2Creator` file. Without this logic, the chart will work fine. 