### PR TITLE
fix chart forceFit

### DIFF
--- a/src/processor/g2Creator.js
+++ b/src/processor/g2Creator.js
@@ -10,7 +10,6 @@ const GEOM_FUNC_PROPS = common.GEOM_FUNC_PROPS;
 export default {
   createChart(config) {
     const chartConfig = config.chart;
-    chartConfig.props.forceFit = false;
     const chart = new G2.Chart(chartConfig.props);
     chartConfig.g2Instance = chart;
     return chart;


### PR DESCRIPTION
according to the #881，#888 and #880 in v3.5.4, chart will be re-rendered twice and a weird flash will appear when forceFit prop is true. I found the forceFit prop was declared as false in the g2Creator class, so the chart will be rendered at the first time without fitting the container, but the ResizeObserver's callback will re-rendered after a delay of 300ms.  Without this logic, the chart will work fine. we can use defaultProps to set forceFit be false.