### PR TITLE
修改Axis的title属性的type类型

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -71,7 +71,7 @@ declare namespace bizcharts{
     name?: string;
     visible?: boolean;
     position?: PositionType;
-    title?: G2.Styles.text | boolean | null;
+    title?: G2.AxisTile | boolean | null;
     line?: G2.Styles.line | null;
     tickLine?: G2.Styles.tickLine | null;
     label?: G2.AxisLabel | null;


### PR DESCRIPTION
根据文档 [Axis(title)](https://bizcharts.net/products/bizCharts/api/axis#title) 描述，title的类型应该是G2.AxisTile | boolean | null，而不是G2.Styles.text | boolean | null