### PR TITLE
docs: 气泡图与 antv g2 示例保存一致 https://antv.alipay.com/zh-cn/g2/3.x/demo/point/…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,6 +29,12 @@
     "class-methods-use-this": "off",
     "comma-dangle": "off",
     "react/require-default-props": "off",
-    "import/no-extraneous-dependencies": "off"
+    "import/no-extraneous-dependencies": "off",
+    "no-unused-vars": "off",
+    "prefer-destructuring": "off",
+    "arrow-body-style": "off",
+    "react/prop-types": "off",
+    "no-param-reassign": "off",
+    "guard-for-in": "off"
   }
 }

--- a/demo/component/point/bubble.js
+++ b/demo/component/point/bubble.js
@@ -28,7 +28,7 @@ const colorMap = {
 };
 
 export default class PointC extends Component {
-  
+
   render() {
     return (
       <Chart height={window.innerHeight} data={data} scale={cols} forceFit>
@@ -39,7 +39,8 @@ export default class PointC extends Component {
           } // 格式化坐标轴的显示
         }} />
         <Axis name='LifeExpectancy'/>
-        <Legend reversed />
+        <Legend />
+        <Legend name="Population" visible={false} />
         <Geom type='point' position="GDP*LifeExpectancy" color={['continent', val => {
           return colorMap[val];
           }]} tooltip='Country*Population*GDP*LifeExpectancy' opacity={0.65} shape="circle" size={['Population', [ 4, 65 ]]} style={['continent', {


### PR DESCRIPTION
1. 气泡图与 antv g2 示例保存一致：设置不展示 Population 图例
https://antv.alipay.com/zh-cn/g2/3.x/demo/point/bubble.html 

2. 修复一些eslint错误