### PR TITLE
fix React.Node to React.ReactElement

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -106,7 +106,7 @@ declare namespace bizcharts{
     pixelRatio?: number;
     data?: any;
     scale?: any;
-    placeholder?: React.Node | string | boolean;
+    placeholder?: React.ReactElement | string | boolean;
     filter?: Array<any>;
     className?: string;
     style?: React.CSSProperties;


### PR DESCRIPTION
```
node_modules/_bizcharts@3.5.6@bizcharts/typings/index.d.ts:109:25 - error TS2694: Namespace 'React' has no exported member 'Node'.

109     placeholder?: React.Node | string | boolean;
                            ~~~~
```