### PR TITLE
根据G2的Tooltip配置类型文件更新BizCharts定义的类型

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -274,7 +274,7 @@ declare namespace bizcharts{
     follow?: boolean;
     shared?: boolean;
     position?: PositionType;
-
+    hideMarkers?: boolean;  
   }
 
 


### PR DESCRIPTION
G2关联文件位置：https://github.com/antvis/G2/blob/d6e6ae36de0a0bd2b7fc4bc3ef5cbf980060d03c/src/index.d.ts#L494
该配置项控制MarkerGroup的显示。
在BizCharts中hideMarkers功能如上，但因缺少类型定义，导致Typescript提示错误。