### PR TITLE
更新color类型定义

### DIFF
--- a/src/geometry/Base.tsx
+++ b/src/geometry/Base.tsx
@@ -70,7 +70,7 @@ export interface IBaseGemo extends IBaseProps, React.Props<any> {
    * @type {(AttributeOption | [ FieldString, ColorString | ColorString[] | ColorAttrCallback ])}
    * @memberof IBaseGemo
    */
-  color?: AttributeOption | [ FieldString, ColorString | ColorString[] | ColorAttrCallback ];
+  color?: AttributeOption | FieldString | ColorString | [ FieldString, ColorString | ColorString[] | ColorAttrCallback ];
   /**
    *
    * @example


### PR DESCRIPTION
> // 使用 '#1890ff' 颜色渲染图形
> ```<Geom color="#1890ff" />```
> 
> // 根据 x 字段的数据值进行颜色的映射，这时候会在内部调用默认的回调函数，读取默认提供的颜> 色进行数据值到颜色值的映射。
> ```<Geom color="x" />```
   
注释里写的这两种 定义上完全没支持