### PR TITLE
fix: 按需加载时Tooltip无法显示(#1215)

### DIFF
--- a/src/components/Tooltip/actions.ts
+++ b/src/components/Tooltip/actions.ts
@@ -10,14 +10,26 @@ registerAction('sibling-tooltip', SiblingTooltip);
 registerAction('active-region', ActiveRegion);
 
 // 注册 tooltip 的 interaction
-registerInteraction('tooltip-hover', {
+registerInteraction('tooltip', {
   // @ts-ignore
-  start: [{ trigger: 'plot:mousemove', action: 'tooltip:show', throttle: { wait: 50, leading: true, trailing: false } }],
+  start: [
+    {
+      trigger: 'plot:mousemove',
+      action: 'tooltip:show',
+      throttle: { wait: 50, leading: true, trailing: false },
+    },
+    {
+      trigger: 'plot:mousedown',
+      action: 'tooltip:show',
+      throttle: { wait: 50, leading: true, trailing: false },
+    },
+  ],
   end: [{ trigger: 'plot:mouseleave', action: 'tooltip:hide' }],
 });
 
-// 点击触发 tooltip事件
-registerInteraction('tooltip-click', {
-  start: [{ trigger: 'plot:mousedown', action: 'tooltip:show', throttle: { wait: 50, leading: true, trailing: false } }],
-  end: [{ trigger: 'plot:mouseleave', action: 'tooltip:hide' }],
+
+// 注册 sibling-tooltip 的 interaction
+registerInteraction('sibling-tooltip', {
+  start: [{ trigger: 'plot:mousemove', action: 'sibling-tooltip:show' }],
+  end: [{ trigger: 'plot:mouseleave', action: 'sibling-tooltip:hide' }],
 });


### PR DESCRIPTION
#1215 这个bug的原因是按需加载的时候Tooltip的相关interaction没有正确注册, registerInteraction函数的第一个参数传入错误，应该是`'tooltip'`, 而不是`'tooltip-hover'`或者`'tooltip-click'`.

全量引入没有这个问题, 是因为全量引入的时候BizCharts的src/g2-all.ts引用了@antv/g2的src/index.ts, 这里面正确注册了Tooltip的interaction, 就覆盖了BizCharts中Tooltip注册的interaction.

本次PR提交的代码参考了@antv/g2中的src/index.ts.