### PR TITLE
feat: 更新依赖版本匹配方式

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,14 +47,14 @@
   "dependencies": {
     "@antv/component": "*",
     "@antv/util": "*",
-    "@antv/g2": "4.1.14",
-    "@antv/g2plot": "2.3.18",
+    "@antv/g2": "^4.1.20",
+    "@antv/g2plot": "^2.3.18",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@babel/plugin-transform-runtime": "^7.12.10",
     "babel-plugin-transform-replace-object-assign": "^2.0.0",
     "d3-color": "^1.4.1",
-    "react-error-boundary": "3.0.2",
-    "react-reconciler": "^0.25.1",
+    "react-error-boundary": "^3.0.2",
+    "react-reconciler": "^0.26.2",
     "resize-observer-polyfill": "^1.5.1",
     "simple-statistics": "^7.1.0",
     "warning": "^4.0.3"


### PR DESCRIPTION
更新依赖匹配规则，防止引入多版本依赖。
同时升级 react-reconciler，兼容 React 17 。

![image](https://user-images.githubusercontent.com/1730277/124685025-04998d00-df03-11eb-9fa9-72efee6dda35.png)

![image](https://user-images.githubusercontent.com/1730277/124685480-ef712e00-df03-11eb-84f3-465a1e75d091.png)


