### PR TITLE
fix: region types for g2 view

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -159,8 +159,14 @@ export interface IViewProps extends React.ComponentPropsWithRef<any> {
   padding?: ViewPadding;
   /** view 的绘制范围，起始点为左上角。 */
   region?: {
-    start?: number | string;
-    end?: number | string;
+    start?: {
+      x: number | string;
+      y: number | string;
+    };
+    end?: {    
+      x: number | string;
+      y: number | string;
+    };
   };
   /**
   * @memberof IView


### PR DESCRIPTION

## description

ViewOption.region

```ts
/** 一个点位置 */
export interface Point {
    readonly x: number;
    readonly y: number;
}
/** 画布范围 */
export interface Region {
    readonly start: Point;
    readonly end: Point;
}
````

IViewProps.region

```ts
{
    /** view 的绘制范围，起始点为左上角。 */
    region?: {
        start?: {
            x: number | string;
            y: number | string;
        };
        end?: {
            x: number | string;
            y: number | string;
        };
    };
}
```