### PR TITLE
feat: g2@3.5.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bizcharts",
-  "version": "3.5.8",
+  "version": "3.5.9",
   "description": "A powerful React chart library based G2 for browser",
   "main": "umd/BizCharts.js",
   "browser": "umd/BizCharts.js",
@@ -43,6 +43,7 @@
   "pre-commit": [
     "lint"
   ],
+  "publishConfig":{ "tag": "v3-latest" },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/alibaba/BizCharts.git"
@@ -56,7 +57,7 @@
     "react": "^15.0.0 || ^16.0.0"
   },
   "dependencies": {
-    "@antv/g2": "3.5.13",
+    "@antv/g2": "3.5.15",
     "@babel/runtime": "^7.7.6",
     "invariant": "^2.2.2",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
报错原因：
集团sura项目首页错误率时间趋势图中用到的集团bizcharts@3.5.9版本的Axis组件与iOS 15 版本不兼容导致整个页面无数据，点击无响应，如果升级到最新4.1.11版本，整个项目涉及到的改动太大，风险太高，并且暂不清楚最新版本是否解决了该兼容问题，稳妥起见，该问题最好是由集团内部负责bizcharts的同学在3.5.9版本去解决