### PR TITLE
fix(WordCloud): extends BasePlotOptions events

### DIFF
--- a/src/plots/WordCloudChart.tsx
+++ b/src/plots/WordCloudChart.tsx
@@ -12,7 +12,7 @@ interface WordStylePolyfill extends WordStyle {
   // gridSize?:number;
 }
 
-export interface WordCloudCfg extends Partial<WordCloudOptions>, BasePlotOptions {
+export interface WordCloudCfg extends Partial<WordCloudOptions>, Omit<BasePlotOptions, 'events'> {
   tooltip?: TooltipAPIOptions;
   wordStyle?: WordStylePolyfill;
   maskImage?: string;


### PR DESCRIPTION
## desc

use Omit to extends types.

## code

```ts
export interface WordCloudCfg extends Partial<WordCloudOptions>, Omit<BasePlotOptions, 'events'> {
    tooltip?: TooltipAPIOptions;
    wordStyle?: WordStylePolyfill;
    maskImage?: string;
    shuffle?: boolean;
    selected?: number;
    events?: {
        onWordCloudHover?: (item: any, dim: any, e: any) => void;
        onWordCloudClick?: (item: any, dim: any, e: any) => void;
    };
}
```