### PR TITLE
增加plot双轴图

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "dependencies": {
     "@antv/component": "*",
-    "@antv/g2": "4.1.30",
-    "@antv/g2plot": "2.3.35",
+    "@antv/g2": "4.1.32",
+    "@antv/g2plot": "2.3.39",
     "@antv/util": "*",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@babel/plugin-transform-runtime": "^7.12.10",

--- a/src/plots/DualAxesChart.tsx
+++ b/src/plots/DualAxesChart.tsx
@@ -1,0 +1,16 @@
+import 'react';
+import { DualAxes, DualAxes as Options } from '@antv/g2plot/lib/plots/dual-axes';
+import createPlot, { BasePlotOptions } from '../createPlot';
+import { LengendAPIOptions, TooltipAPIOptions, LabelAPIOptions } from './core/interface';
+
+interface DualAxesOptions extends Options, BasePlotOptions {
+  /** 图例 */
+  legend?: LengendAPIOptions;
+  /** 图表提示框 */
+  tooltip?: TooltipAPIOptions;
+  /** 数据标注label */
+  label?: LabelAPIOptions;
+}
+// 直方图
+export { DualAxesOptions };
+export default createPlot<DualAxesOptions>(DualAxes, 'DualAxesChart');

--- a/src/plots/plots.tsx
+++ b/src/plots/plots.tsx
@@ -33,5 +33,6 @@ export { default as BubbleChart } from './BubbleChart';
 export { default as BulletChart } from './BulletChart';
 export { default as CalendarChart } from './CalendarChart';
 export { default as GaugeChart } from './GaugeChart';
+export { default as DualAxesChart } from './DualAxesChart';
 
 


### PR DESCRIPTION
1. 升级g2版本到4.1.30
2. 升级g2plot到2.3.39
3. 增加双轴图