### PR TITLE
Update antv/g2plot: fixed build issue with Vite yarn typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@antv/component": "*",
     "@antv/g2": "4.1.32",
-    "@antv/g2plot": "2.3.39",
+    "@antv/g2plot": "2.4.15",
     "@antv/util": "*",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@babel/plugin-transform-runtime": "^7.12.10",


### PR DESCRIPTION
BizCharts Version: ^4.1.15
Platform: macOS M1
Mini Showcase(like screenshots):
![image](https://user-images.githubusercontent.com/32700499/163595475-e901cea7-1f7d-4c84-97da-5e7c22e2a0b2.png)

Environment:

- node: 17.4.0
- react: 17.0.2
- bundler(vite): 2.7.2
- @types/node: 17.0.19
- @types/react: 17.0.33
- typescript: ^4.4.4
- yarn: ^1.22.17

Updated antv/g2plot to version `@antv/g2plot: 2.4.15`.

by updating it to version 2.4.15 the `defaultColor` param is set to optional in `@antv/g2plot/lib/plots/venn/types.d.ts`